### PR TITLE
[TSG] Backporting for 2.1 (pr56) (2.1.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 * Added an ability scroll to left if element is overlapped by another element
+* Added support of PHP 7.1
+* Ignore PEER verification for curl transfer
 
 1.0.0-rc.47
 ===========

--- a/Magento/Mtf/System/JUnit.php
+++ b/Magento/Mtf/System/JUnit.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright © 2016 Magento. All rights reserved.
+ * Copyright © 2018 Magento. All rights reserved.
  * See COPYING.txt for license details.
  */
 
@@ -66,7 +66,10 @@ class JUnit extends \PHPUnit_Util_Log_JUnit
             $errors = $xpath->query('//testsuite[@name="' . $class->name . '"]//failure')->length;
             $entries->item(0)->setAttribute("failures", $errors);
 
-            $entries->item(0)->setAttribute("time", $entries->item(0)->getAttribute("time") + $time);
+            $entries->item(0)->setAttribute(
+                "time",
+                (float)$entries->item(0)->getAttribute("time") + (float)$time
+            );
 
             if (method_exists($test, 'hasOutput') && $test->hasOutput()) {
                 $systemOut = $this->document->createElement('system-out');

--- a/Magento/Mtf/Util/Protocol/CurlTransport.php
+++ b/Magento/Mtf/Util/Protocol/CurlTransport.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright © 2016 Magento. All rights reserved.
+ * Copyright © 2018 Magento. All rights reserved.
  * See COPYING.txt for license details.
  */
 
@@ -124,6 +124,7 @@ class CurlTransport implements CurlInterface
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_COOKIEFILE => '',
             CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_SSL_VERIFYPEER => false,
         ];
         switch ($method) {
             case CurlInterface::POST:


### PR DESCRIPTION
## Scope

### Bug - P1
* [MAGETWO-92836](https://jira.corp.magento.com/browse/MAGETWO-92836) [Backport for 2.1.x] Support for PHP 7.1

### Bamboo CI builds

* [x] [M2 L4 (PHP 5.5)](https://bamboo.corp.magento.com/browse/MCCE21DEV-L41049/latest)
* [x] [PAT](https://bamboo.corp.magento.com/browse/MCCE21DEV-PAT402/latest)

### Related Pull Requests

- CE https://github.com/magento/magento2ce/pull/3034
- EE https://github.com/magento/magento2ee/pull/1149
- Infrastructure https://github.com/magento/magento2-infrastructure/pull/622
- Sample Data https://github.com/magento/magento2-sample-data/pull/95
- Sample Data EE https://github.com/magento/magento2-sample-data-ee/pull/36

### CE Checklist

- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Unit, Extended FAT CE, Extended FAT EE and Extended FAT B2B builds are green


Created by : @zakdma
Internal PR: https://github.com/magento-tsg/mtf/pull/4