### PR TITLE
[Techdivision] Add PHP 7.3 support

### DIFF
--- a/Magento/Mtf/Client/Element/SelectElement.php
+++ b/Magento/Mtf/Client/Element/SelectElement.php
@@ -91,7 +91,7 @@ class SelectElement extends SimpleElement
      */
     protected function escapeQuotes($toEscape)
     {
-        if (strpos($toEscape, '"') !== false && strpos($toEscape, "'" != false)) {
+        if (strpos($toEscape, '"') !== false && strpos($toEscape, "'") !== false) {
             $subStrings = explode('"', $toEscape);
             $escaped = "concat(";
             $first = true;
@@ -106,7 +106,7 @@ class SelectElement extends SimpleElement
             return $escaped;
         }
 
-        if (strpos($toEscape, '"' !== false)) {
+        if (strpos($toEscape, '"') !== false) {
             return sprintf("'%s'", $toEscape);
         }
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["automation", "magento", "testing"],
     "license": "OSL-3.0",
     "require": {
-        "php": ">=5.4.0|~7.2.0",
+        "php": "~7.1.0||~7.2.0||~7.3.0",
         "phpunit/phpunit": "~6.5.0",
         "phpunit/phpunit-selenium": "~4.1.0",
         "symfony/console": "~4.1.0",


### PR DESCRIPTION
## Scope
### Story
* [MC-16705](https://jira.corp.magento.com/browse/MC-16705) Upgrade composer.json to suport PHP 7.3 for M2.3

### Bamboo CI Builds
* [ ] [M2, CI (CE + EE) - 2.3-develop - Performance Acceptance Test](https://bamboo.corp.magento.com/browse/MCCE23-PAT3180/latest)

### Related Pull Requests
https://github.com/magento/magento2ce/pull/4488
https://github.com/magento/magento2ee/pull/1830
https://github.com/magento/magento2b2b/pull/775
https://github.com/magento/magento2-infrastructure/pull/886
https://github.com/magento/magento2-sample-data/pull/122
https://github.com/magento/magento2-sample-data-ee/pull/42

### Checklist
- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Extended FAT build is green
