### PR TITLE
Rename php-webdriver package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "suggest": {
         "netwing/selenium-server-standalone": "dev-master",
-        "facebook/webdriver": "dev-master"
+        "php-webdriver/webdriver": "dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Php-webdriver package [has been renamed](https://github.com/php-webdriver/php-webdriver/issues/730#issuecomment-575601572) and the original is now marked as abandoned (and will not receive any updates).

```sh
$ composer install
Package facebook/php-webdriver is abandoned, you should avoid using it. Use php-webdriver/webdriver instead.
```